### PR TITLE
Add `callback` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ gulp.task('css', function() {
 - **throwError** (boolean, default = `false`)
 
   If `true`, after the plugin logs your warnings it will throw an error if it found any warnings.
+
+- **callback** (function, default = `warnings => console.log(warnings)`)
+
+  Receives a formatted string containing all warnings, as well as a PostCSS
+  `Result` instance. This allows another plugin to use postcss-log-warnings as a
+  library and display the warnings in a different way.

--- a/index.js
+++ b/index.js
@@ -12,10 +12,15 @@ module.exports = postcss.plugin('postcss-log-warnings', function(options) {
 
     if (!warningLog) return;
 
-    console.log(warningLog);
+    var callback = options.callback || defaultCallback;
+    callback(warningLog, result);
 
     if (options.throwError) {
       throw new Error(chalk.red.bold('\n** postcss-log-warnings: warnings were found **'));
     }
   };
 });
+
+function defaultCallback(warningLog) {
+  console.log(warningLog);
+}


### PR DESCRIPTION
This allows another plugin, such as postcss-messages, to use
postcss-log-warnings as a library and display the warnings in a different way.
