### PR TITLE
Define lib/processResult.js as a public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ gulp.task('css', function() {
 
 *By default, this plugin will clear the warnings after it logs them*. Otherwise, your other plugins or your PostCSS runner might re-print the same warnings, causing some confusion. This can be changed by setting the option `{ keepWarnings: true }`.
 
+You can also use this module as a library:
+
+```js
+var processResult = require('postcss-log-warnings/lib/processResult');
+var warningLog = processResult(postcssResult, options);
+```
+
 ### Options
 
 - **keepWarnings** (boolean, default = `false`)
@@ -55,3 +62,4 @@ gulp.task('css', function() {
 - **throwError** (boolean, default = `false`)
 
   If `true`, after the plugin logs your warnings it will throw an error if it found any warnings.
+  (Not part of the library options.)


### PR DESCRIPTION
This allows another plugin, such as postcss-messages, to use
postcss-log-warnings as a library and display the warnings in a different way.

See #7 and #9.
